### PR TITLE
[ECO-2195] Stencil starter not working.

### DIFF
--- a/src/helper/index.js
+++ b/src/helper/index.js
@@ -1,7 +1,8 @@
 import Stack from '../sdk-plugin';
 import { addEditableTags } from '@contentstack/utils';
+import { Env } from '@stencil/core';
 
-const liveEdit = process.env.CONTENTSTACK_LIVE_EDIT_TAGS === 'true';
+const liveEdit = Env.CONTENTSTACK_LIVE_EDIT_TAGS === 'true';
 
 export const getHeaderRes = async () => {
   const response = await Stack.getEntry({


### PR DESCRIPTION
Fixed parsing env variables from process into Env and then futher to config. It seems, FS started working wrongly from some moment, and ideally node:fs had to be used.